### PR TITLE
Add `accounting_noise_multiplier` property for correct privacy accounting

### DIFF
--- a/opacus/accountants/accountant.py
+++ b/opacus/accountants/accountant.py
@@ -80,7 +80,7 @@ class IAccountant(abc.ABC):
             # The reason is that the sample rate is the same in both cases (but in
             # distributed mode, each node samples among a subset of the data)
             self.step(
-                noise_multiplier=optim.noise_multiplier,
+                noise_multiplier=optim.accounting_noise_multiplier,
                 sample_rate=sample_rate * optim.accumulated_iterations,
             )
 

--- a/opacus/optimizers/adaclipoptimizer.py
+++ b/opacus/optimizers/adaclipoptimizer.py
@@ -76,6 +76,10 @@ class AdaClipDPOptimizer(DPOptimizer):
         self.max_clipbound = max_clipbound
         self.min_clipbound = min_clipbound
         self.unclipped_num_std = unclipped_num_std
+        # Store the original noise_multiplier for privacy accounting.
+        # The adjusted noise_multiplier is used for noise generation, but
+        # the accountant needs the original value for correct privacy calculations.
+        self._original_noise_multiplier = self.noise_multiplier
         # Theorem 1. in  https://arxiv.org/pdf/1905.03871.pdf
         if self.noise_multiplier > 0:  # if noise_multiplier = 0 then it stays zero
             self.noise_multiplier = (
@@ -83,6 +87,17 @@ class AdaClipDPOptimizer(DPOptimizer):
             ) ** (-1 / 2)
         self.sample_size = 0
         self.unclipped_num = 0
+
+    @property
+    def accounting_noise_multiplier(self) -> float:
+        """
+        Returns the original noise multiplier for privacy accounting.
+
+        AdaClip internally adjusts noise_multiplier based on Theorem 1 from
+        https://arxiv.org/pdf/1905.03871.pdf, but the accountant should use
+        the original user-provided value for correct privacy budget calculation.
+        """
+        return self._original_noise_multiplier
 
     def zero_grad(self, set_to_none: bool = False):
         """

--- a/opacus/optimizers/optimizer.py
+++ b/opacus/optimizers/optimizer.py
@@ -417,6 +417,18 @@ class DPOptimizer(Optimizer):
         """
         self.original_optimizer.defaults = defaults
 
+    @property
+    def accounting_noise_multiplier(self) -> float:
+        """
+        Returns the noise multiplier value to be used for privacy accounting.
+
+        For standard DPOptimizer, this is the same as ``noise_multiplier``.
+        Subclasses that internally adjust ``noise_multiplier`` (e.g., AdaClipDPOptimizer)
+        should override this property to return the original user-provided value,
+        ensuring correct privacy accounting.
+        """
+        return self.noise_multiplier
+
     def attach_step_hook(self, fn: Callable[[DPOptimizer], None]):
         """
         Attaches a hook to be executed after gradient clipping/noising, but before the


### PR DESCRIPTION


AdaClipDPOptimizer internally adjusts `noise_multiplier` based on Theorem 1 from https://arxiv.org/pdf/1905.03871.pdf. However, the accountant hook was reading this adjusted value instead of the original user-provided value, leading to incorrect privacy budget calculations.

This fix introduces an `accounting_noise_multiplier` property:
- DPOptimizer: returns `self.noise_multiplier` (default behavior)
- AdaClipDPOptimizer: overrides to return the original value

The accountant hook now uses this property, ensuring correct privacy accounting regardless of optimizer implementation details.

## Types of changes

<!--- What types of changes does your code introduce? Please mark an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Docs change / refactoring / dependency upgrade

## Motivation and Context / Related issue

<!--- What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested (if it applies)

<!--- Please describe here how your modifications have been tested. -->

## Checklist

<!--- Please go over all the following points, and mark an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] The documentation is up-to-date with the changes I made.
- [ ] I have read the **CONTRIBUTING** document and completed the CLA (see **CONTRIBUTING**).
- [ ] All tests passed, and additional code has been covered with new tests.
